### PR TITLE
Fix game-state bug - returning "draw" instead of "won"

### DIFF
--- a/spec/minimax_server/game_state_spec.clj
+++ b/spec/minimax_server/game_state_spec.clj
@@ -30,4 +30,9 @@
   (it "reports that game is 'inProgress' when game is not over"
     (let [request (ttt-request "x" "x,x,_,o,o,_,_,_,_")]
       (should= "inProgress"
+        (:gameState (response-data (.apply (game-state-service) request))))))
+
+  (it "reports that the game is 'won' when board is full and a player won"
+    (let [request (ttt-request "o" "x,x,x,o,o,x,x,o,o")]
+      (should= "won"
         (:gameState (response-data (.apply (game-state-service) request)))))))

--- a/spec/minimax_server/tic_tac_toe_spec.clj
+++ b/spec/minimax_server/tic_tac_toe_spec.clj
@@ -51,6 +51,20 @@
                    :o :x :x]]
         (should= false (player-won? :o board)))))
 
+  (context "draw game detection"
+
+    (it "returns true if board is full and no player has won"
+      (let [board [:x :o :x
+                   :x :o :o
+                   :o :x :x]]
+        (should= true (is-draw? board))))
+
+    (it "returns false if board is full and a player has won"
+      (let [board [:x :x :x
+                   :x :o :o
+                   :o :o :x]]
+        (should= false (is-draw? board)))))
+
   (context "game over detection"
 
     (it "should be false if game is not over"

--- a/src/minimax_server/tic_tac_toe.clj
+++ b/src/minimax_server/tic_tac_toe.clj
@@ -1,18 +1,22 @@
 (ns minimax-server.tic-tac-toe)
 
-(def board-line-indexes
-  [[0 1 2] [3 4 5] [6 7 8] [0 3 6] [1 4 7] [2 5 8] [0 4 8] [2 4 6]])
-
 (def any? (comp boolean some))
 
 (defn winning-line? [line-indexes mark board]
   (every? #(= mark %) (map #(nth board %) line-indexes)))
 
 (defn player-won? [player-mark board]
-  (any? #(winning-line? % player-mark board) board-line-indexes))
+  (let [board-line-indexes [[0 1 2] [3 4 5] [6 7 8] [0 3 6] [1 4 7] [2 5 8] [0 4 8] [2 4 6]]]
+    (any? #(winning-line? % player-mark board) board-line-indexes)))
+
+(defn is-full? [board]
+  (not-any? #(= :_ %) board))
 
 (defn is-draw? [board]
-  (not-any? #(= :_ %) board))
+  (and
+    (is-full? board)
+    (not (player-won? :x board))
+    (not (player-won? :o board))))
 
 (defn game-over? [board]
   (or (is-draw? board) (player-won? :x board) (player-won? :o board)))


### PR DESCRIPTION
- When board is full and player has won, game-state erroneously
  reported that the game was a draw.
